### PR TITLE
fix backspace not working

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -2,6 +2,7 @@
 let mapleader = " "
 
 set backspace=2   " Backspace deletes like most programs in insert mode
+set backspace=indent,eol,start
 set nobackup
 set nowritebackup
 set noswapfile    " http://robots.thoughtbot.com/post/18739402579/global-gitignore#comment-458413287


### PR DESCRIPTION
When pressing backspace in insert mode, it appears some strange characters.

http://vim.wikia.com/wiki/Backspace_and_delete_problems

