### PR TITLE
permits navigation in ruby files and add vimrc alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -1,5 +1,6 @@
 alias aliases="vim ~/dotfiles/aliases.local"
 alias gitconfig="vim ~/dotfiles/gitconfig.local"
+alias vimrc="vim ~/dotfiles/vimrc"
 
 alias gs="git status"
 

--- a/vimrc
+++ b/vimrc
@@ -25,6 +25,12 @@ if filereadable(expand("~/.vimrc.bundles"))
   source ~/.vimrc.bundles
 endif
 
+" permits navigates in requires as hyperlinks
+augroup rubypath
+  autocmd FileType ruby setlocal suffixesadd+=.rb
+  autocmd FileType ruby setlocal path+=~/workspace/bankfacil/core/**
+augroup END
+
 " Load matchit.vim, but only if the user hasn't installed a newer version.
 if !exists('g:loaded_matchit') && findfile('plugin/matchit.vim', &rtp) ==# ''
   runtime! macros/matchit.vim


### PR DESCRIPTION
with the added code, it's possible to navigate in require paths with `gf` command

```
require 'crm/auto_refi/lead'
```

with a cursor in anyplace in this line, when you type `gf` you navigate to lead.rb. Type `<C-o>` to return.