### PR TITLE
remove commands that are not working properly

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -10,18 +10,8 @@ bind-key -n C-l select-pane -R
 bind-key -r c-h select-window -t :-
 bind-key -r c-l select-window -t :+
 
-# Just for macOS
-# Setup 'v' to being selection as in Vim
-bind-key -t vi-copy v begin-selection
-bind-key -t vi-copy copy-pipe "reattach-to-user-namespace pbcopy"
-# Update default binding of 'Enter' to also use copy-pipe 
-unbind -t vi-copy Enter
-bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
-
 # improve split
-
 bind-key x split-window -v -c '#{pane_current_path}'
-
 bind c new-window -c '#{pane_current_path}'
 
 # resizing


### PR DESCRIPTION
removing some keybinds to simulate vim shortcuts to copy from terminal

It seems those keybinds are not working anymore in newer versions of tmux
https://thoughtbot.com/upcase/videos/tmux-navigation